### PR TITLE
Adding explicit reference to Bundle.entry.search.score

### DIFF
--- a/input/pagecontent/patient-matching.md
+++ b/input/pagecontent/patient-matching.md
@@ -94,6 +94,7 @@ Patient Match **SHOULD** be in terms of groups of records that have been partiti
 
 - For example, a candidate Identity that has the right address in one record, the right name in another, and the right telephone in another could be a strong candidate, even though no single record contains all the given information.  
   
+
 To request a match on a patient with a single legal name, known as a mononamous individual, requestors **SHOULD** use that name in the Last name field and leave the First name NULL.
 
 Patient Match need not support wildcards, unlike the usual FHIR search mechanism.
@@ -195,7 +196,7 @@ Common correlations such as families **SHALL** be modeled *<u>(ONC recommendatio
 
 Scores **SHOULD** be computed, not guessed, whenever possible.
 
-The table below which designates a grading of match quality **SHOULD** be used to inform responder's search quality scoring algorithm, so that the search score returned by a responder is meaningful to the requestor; feedback is requested on the ability of a responder to compute and return such a score, as well as the potential value of such a quality score to requesters. The Good level generally corresponds to traits the [Sequoia Initiative](https://sequoiaproject.org/resources/patient-matching/) estimates to be 95-98% unique, and Very Good corresponds to traits that are 98-99.7% unique. Superior matches include matching information that is even more likely to indicate a unique individual, while Best matches involve a match on a government- or industry-assigned identifier.  
+The table below which designates a grading of match quality **SHOULD** be used to inform responder's search quality scoring algorithm, so that the search score returned by a responder is meaningful to the requestor (This grading score **SHOULD** be conveyed within the Bundle.entry.search.score element); feedback is requested on the ability of a responder to compute and return such a score, as well as the potential value of such a quality score to requesters. The Good level generally corresponds to traits the [Sequoia Initiative](https://sequoiaproject.org/resources/patient-matching/) estimates to be 95-98% unique, and Very Good corresponds to traits that are 98-99.7% unique. Superior matches include matching information that is even more likely to indicate a unique individual, while Best matches involve a match on a government- or industry-assigned identifier.  
 
 <style>
 table, th, td 


### PR DESCRIPTION
While this section mentions the grading score table and that it SHOULD be used, it did not explicitly mention that it SHOULD be conveyed through the Bundle.entry.search.score element.  The statement I added clarifies this expectation.